### PR TITLE
Add russian translation

### DIFF
--- a/po/ru.po
+++ b/po/ru.po
@@ -1,0 +1,684 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: BetterTrayIcons\n"
+"Report-Msgid-Bugs-To: https://github.com/nexaknight/BetterTrayIcons/issues\n"
+"POT-Creation-Date: 2026-05-11 10:26+0200\n"
+"PO-Revision-Date: 2026-07-06 02:54+0800\n"
+"Last-Translator: Igor Zhitov <agent19872@icloud.com>\n"
+"Language-Team: Russian\n"
+"Language: ru\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
+"n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
+"X-Generator: Gtranslator 50.0\n"
+
+msgid "About"
+msgstr "О расширении"
+
+msgid "Action Menu"
+msgstr "Меню действий"
+
+msgid "Actions"
+msgstr "Действия"
+
+msgid "Activate"
+msgstr "Активировать"
+
+msgid "Advanced"
+msgstr "Дополнительно"
+
+msgid "All Icons"
+msgstr "Все значки"
+
+msgid "All settings will be restored to defaults and sync backups deleted. This "
+"cannot be undone."
+msgstr "Все настройки будут сброшены до значений по умолчанию, а резервные копии "
+"синхронизации удалены. Это действие нельзя отменить."
+
+msgid "Appearance"
+msgstr "Внешний вид"
+
+msgid "Applications"
+msgstr "Приложения"
+
+msgid "Apply"
+msgstr "Применить"
+
+msgid "App Settings"
+msgstr "Настройки приложения"
+
+msgid "A shared JSON file on Nextcloud, a NAS, or another cloud folder."
+msgstr "Общий JSON-файл в Nextcloud, на NAS или в другой облачной папке."
+
+msgid "Auto-Sync"
+msgstr "Автосинхронизация"
+
+msgid "Background"
+msgstr "Фон"
+
+msgid "Background Color"
+msgstr "Цвет фона"
+
+msgid "Background, radius, spacing"
+msgstr "Фон, радиус и интервалы"
+
+msgid "Backup"
+msgstr "Резервная копия"
+
+msgid "Backup and Restore"
+msgstr "Резервное копирование и восстановление"
+
+msgid "Backup restored"
+msgstr "Резервная копия восстановлена"
+
+msgid "Backups"
+msgstr "Резервные копии"
+
+msgid "Behavior"
+msgstr "Поведение"
+
+msgid "Bottom"
+msgstr "Снизу"
+
+msgid "Cancel"
+msgstr "Отмена"
+
+msgid "Center"
+msgstr "По центру"
+
+msgid "Changelog"
+msgstr "Журнал изменений"
+
+msgid "Checking…"
+msgstr "Проверка…"
+
+msgid "Choose file"
+msgstr "Выбрать файл"
+
+msgid "Clean Up"
+msgstr "Очистить"
+
+msgid "Clean Up Legacy IDs"
+msgstr "Очистить устаревшие ID"
+
+msgid "Cloud Sync"
+msgstr "Облачная синхронизация"
+
+msgid "Colors"
+msgstr "Цвета"
+
+msgid "Configuration"
+msgstr "Настройки"
+
+msgid "Configure"
+msgstr "Настроить"
+
+msgid "Configure advanced actions"
+msgstr "Настроить дополнительные действия"
+
+msgid "Confirm"
+msgstr "Подтвердить"
+
+msgid "Contacts api.github.com on demand."
+msgstr "Обращается к api.github.com по запросу."
+
+msgid "Contributors"
+msgstr "Участники"
+
+msgid "Copy logs"
+msgstr "Скопировать журнал отладки"
+
+msgid "Corner Radius (px)"
+msgstr "Радиус углов (px)"
+
+msgid "Custom"
+msgstr "Пользовательский"
+
+msgid "Custom Icon"
+msgstr "Пользовательский значок"
+
+msgid "Custom Style"
+msgstr "Пользовательский стиль"
+
+msgid "Cycle Icons"
+msgstr "Переключение значков"
+
+msgid "Danger Zone"
+msgstr "Опасная зона"
+
+msgid "Debug Mode"
+msgstr "Режим отладки"
+
+msgid "Default app icon"
+msgstr "Стандартный значок приложения"
+
+msgid "Deletes all stored settings for this app."
+msgstr "Удаляет все сохранённые настройки этого приложения."
+
+msgid "Detected Apps"
+msgstr "Найденные приложения"
+
+msgid "Don’t show this icon in the tray."
+msgstr "Не показывать этот значок в трее."
+
+msgid "Double Click"
+msgstr "Двойное нажатие"
+
+msgid "Enable"
+msgstr "Включить"
+
+msgid "Error loading data"
+msgstr "Ошибка загрузки данных"
+
+msgid "Experimental"
+msgstr "Экспериментально"
+
+msgid "Export"
+msgstr "Экспорт"
+
+msgid "Factory Reset"
+msgstr "Сброс к заводским настройкам"
+
+msgid "Failed to load changelog: "
+msgstr "Не удалось загрузить журнал изменений: "
+
+msgid "File"
+msgstr "Файл"
+
+msgid "File Chooser"
+msgstr "Выбор файла"
+
+msgid "File is not valid JSON"
+msgstr "Файл не является допустимым JSON"
+
+msgid "File not yet created"
+msgstr "Файл ещё не создан"
+
+msgid "Forget"
+msgstr "Забыть"
+
+msgid "Forget App"
+msgstr "Забыть приложение"
+
+msgid "from"
+msgstr "с"
+
+msgid "General"
+msgstr "Общее"
+
+msgid "Grid"
+msgstr "Сетка"
+
+msgid "Grid Columns"
+msgstr "Столбцы сетки"
+
+msgid "Help translate this extension."
+msgstr "Помогите перевести это расширение."
+
+msgid "Hidden"
+msgstr "Скрыто"
+
+msgid "Hide Icon"
+msgstr "Скрыть значок"
+
+msgid "Higher values move the icon further left."
+msgstr "Большие значения смещают значок левее."
+
+msgid "Horizontal (px)"
+msgstr "Горизонтально (px)"
+
+msgid "Hover"
+msgstr "При наведении"
+
+msgid "Icon"
+msgstr "Значок"
+
+msgid "Icon Color"
+msgstr "Цвет значка"
+
+msgid "Icon name or path"
+msgstr "Имя значка или путь"
+
+msgid "Icon, position, colors"
+msgstr "Значок, расположение и цвета"
+
+msgid "Icon Size (px)"
+msgstr "Размер значка (px)"
+
+msgid "ID"
+msgstr "ID"
+
+msgid "Image Files"
+msgstr "Файлы изображений"
+
+msgid "Import"
+msgstr "Импорт"
+
+msgid "Import settings?"
+msgstr "Импортировать настройки?"
+
+msgid "Information"
+msgstr "Информация"
+
+msgid "Inherit Style from Tray Icons"
+msgstr "Наследовать стиль значков трея"
+
+msgid "Keep Overflow Menu Open"
+msgstr "Оставлять меню скрытых значков открытым"
+
+msgid "Keep settings in sync via a shared file."
+msgstr "Синхронизация настроек через общий файл."
+
+msgid "Last Sync"
+msgstr "Последняя синхронизация"
+
+msgid "Layout"
+msgstr "Макет"
+
+msgid "Left"
+msgstr "Слева"
+
+msgid "Left Click"
+msgstr "Левая кнопка"
+
+msgid "Legal"
+msgstr "Правовые сведения"
+
+msgid "License"
+msgstr "Лицензия"
+
+msgid "Load"
+msgstr "Загрузить"
+
+msgid "Loaded from GitHub"
+msgstr "Загрузить с GitHub"
+
+msgid "Loading…"
+msgstr "Загрузка…"
+
+msgid "Local settings will be overwritten."
+msgstr "Локальные настройки будут перезаписаны."
+
+msgid "Logs copied"
+msgstr "Журнал отладки скопирован"
+
+msgid "Logs saved"
+msgstr "Журнал отладки сохранён"
+
+msgid "Log to journalctl."
+msgstr "Записывать в journalctl."
+
+msgid "Long Press"
+msgstr "Удержание"
+
+msgid "Manual Sync"
+msgstr "Ручная синхронизация"
+
+msgid "Margin"
+msgstr "Внешние отступы"
+
+msgid "Match the look of tray icons; hides the controls below."
+msgstr "Использует внешний вид значков трея и скрывает настройки ниже."
+
+msgid "Menu items still close immediately on click."
+msgstr "Пункты меню всё равно закрываются сразу при нажатии."
+
+msgid "More colors"
+msgstr "Дополнительные цвета"
+
+msgid "Middle Click"
+msgstr "Средняя кнопка"
+
+msgid "Name"
+msgstr "Название"
+
+msgid "Next"
+msgstr "Следующая страница"
+
+msgid "No apps detected"
+msgstr "Приложения не найдены"
+
+msgid "No contributors found"
+msgstr "Участники не найдены"
+
+msgid "No file selected"
+msgstr "Файл не выбран"
+
+msgid "No logs found"
+msgstr "Логи не найдены"
+
+msgid "None"
+msgstr "Ничего"
+
+msgid "None available"
+msgstr "Нет доступных резервных копий"
+
+msgid "No releases found."
+msgstr "Выпуски не найдены."
+
+msgid "Open"
+msgstr "Открыть"
+
+msgid "Open Menu"
+msgstr "Открыть меню"
+
+msgid "Open on GitHub"
+msgstr "Открыть на GitHub"
+
+msgid "Open Overflow Menu"
+msgstr "Открыть меню скрытых значков"
+
+msgid "Open Settings"
+msgstr "Открыть настройки"
+
+msgid "Open the gear for double-click and long-press."
+msgstr "Нажмите шестерёнку, чтобы настроить двойное нажатие и удержание."
+
+msgid "Order"
+msgstr "Порядок"
+
+msgid "Overflow Container"
+msgstr "Контейнер меню скрытых значков"
+
+msgid "Overflow Layout"
+msgstr "Макет меню скрытых значков"
+
+msgid "Overflow Menu"
+msgstr "Меню скрытых значков"
+
+msgid "Padding"
+msgstr "Внутренние отступы"
+
+msgid "Panel Box"
+msgstr "Область панели"
+
+msgid "Position"
+msgstr "Расположение"
+
+msgid "Position in Box"
+msgstr "Положение в области"
+
+msgid "Powered by"
+msgstr "Предоставлено"
+
+msgid "Previous"
+msgstr "Предыдущая страница"
+
+msgid "Proton"
+msgstr "Proton"
+
+msgid "Provided \"as is\", without warranty. The authors are not liable for damages."
+msgstr "Предоставляется \"как есть\", без каких-либо гарантий. Авторы не несут "
+"ответственности за возможный ущерб."
+
+msgid "Pull"
+msgstr "Получить"
+
+msgid "Pull failed"
+msgstr "Не удалось получить"
+
+msgid "Pull from file?"
+msgstr "Получить из файла?"
+
+msgid "Pull from File"
+msgstr "Получить из файла"
+
+msgid "Push"
+msgstr "Отправить"
+
+msgid "Push failed"
+msgstr "Не удалось отправить"
+
+msgid "Push on change, pull on remote update."
+msgstr "Отправляет при изменении и получает при обновлении удалённого файла."
+
+msgid "Push to File"
+msgstr "Отправить в файл"
+
+msgid "Recent releases"
+msgstr "Последние выпуски"
+
+msgid "Recommended"
+msgstr "Рекомендуется"
+
+msgid "Relative to the tray icons."
+msgstr "Относительно значков трея."
+
+msgid "Remove leftovers from earlier versions."
+msgstr "Удаление остатков от ранних версий."
+
+msgid "Reorder (drag & drop)"
+msgstr "Изменение порядка (перетаскиванием)"
+
+msgid "Reset"
+msgstr "Сбросить"
+
+msgid "Reset all settings?"
+msgstr "Сбросить все настройки?"
+
+msgid "Reset icon"
+msgstr "Сбросить значок"
+
+msgid "Reset name"
+msgstr "Сбросить название"
+
+msgid "Restore"
+msgstr "Восстановить"
+
+msgid "Reveal colors, padding and margin controls below."
+msgstr "Показывать ниже настройки цветов, внутренних и внешних отступов."
+
+msgid "Restore defaults and delete sync backups."
+msgstr "Сбросить настройки и удалить резервные копии синхронизации."
+
+msgid "Restore failed: %s"
+msgstr "Не удалось восстановить: %s"
+
+msgid "Restore this backup?"
+msgstr "Восстановить эту резервную копию?"
+
+msgid "Right"
+msgstr "Справа"
+
+msgid "Right Click"
+msgstr "Правая кнопка"
+
+msgid "Row"
+msgstr "Строка"
+
+msgid "Run an app with a tray icon to see it here."
+msgstr "Запустите приложение со значком в трее, чтобы увидеть его здесь."
+
+msgid "Save"
+msgstr "Сохранить"
+
+msgid "Save logs"
+msgstr "Сохранить журнал отладки"
+
+msgid "Save settings as JSON or load them back."
+msgstr "Сохранение настроек в JSON и восстановление из него."
+
+msgid "Schema key \"sync-file-path\" missing."
+msgstr "Ключ \"sync-file-path\" отсутствует в схеме."
+
+msgid "Search icons…"
+msgstr "Поиск значков…"
+
+msgid "Select Icon"
+msgstr "Выбрать значок"
+
+msgid "Select Image"
+msgstr "Выбрать изображение"
+
+msgid "Select one to restore"
+msgstr "Выберите резервную копию для восстановления"
+
+msgid "Set a file path first."
+msgstr "Сначала укажите путь к файлу синхронизации."
+
+msgid "Settings"
+msgstr "Настройки"
+
+msgid "Settings persist after the app closes."
+msgstr "Настройки сохраняются после закрытия приложения."
+
+msgid "Settings pulled"
+msgstr "Настройки получены"
+
+msgid "Settings pushed"
+msgstr "Настройки отправлены"
+
+msgid "Settings reset"
+msgstr "Настройки сброшены"
+
+msgid "Shape"
+msgstr "Форма"
+
+msgid "Show icons from Wine and Proton apps."
+msgstr "Показывать значки приложений Wine и Proton."
+
+msgid "Show more"
+msgstr "Показать ещё"
+
+msgid "Show the app title on hover."
+msgstr "Показывать название приложения при наведении."
+
+msgid ""
+"Single clicks are briefly delayed while a double-click action is set, so the "
+"second click can be detected."
+msgstr ""
+"Если задано действие для двойного нажатия, одиночные нажатия срабатывают с "
+"небольшой задержкой, чтобы можно было распознать второе нажатие."
+
+msgid "Show Tooltips"
+msgstr "Показывать подсказки"
+
+msgid "Side"
+msgstr "Сторона"
+
+msgid "Size"
+msgstr "Размер"
+
+msgid "Size, padding, colors"
+msgstr "Размер, отступы и цвета"
+
+msgid "Size (px)"
+msgstr "Размер (px)"
+
+msgid "Source Code"
+msgstr "Исходный код"
+
+msgid "Sponsor"
+msgstr "Спонсировать"
+
+msgid "Style"
+msgstr "Стиль"
+
+msgid "Support development."
+msgstr "Поддержать разработку."
+
+msgid "Symbolic Icons"
+msgstr "Символические значки"
+
+msgid "Sync File"
+msgstr "Файл синхронизации"
+
+msgid "System Icons"
+msgstr "Системные значки"
+
+msgid "this device"
+msgstr "этого устройства"
+
+msgid "Toggle Button"
+msgstr "Кнопка скрытых значков"
+
+msgid "Toggle Button Clicks"
+msgstr "Действия кнопки скрытых значков"
+
+msgid "Toggle Menu"
+msgstr "Переключить меню"
+
+msgid "Tooltip Delay (ms)"
+msgstr "Задержка подсказки (мс)"
+
+msgid "Tooltip Position"
+msgstr "Положение подсказки"
+
+msgid "Top"
+msgstr "Сверху"
+
+msgid "Translate"
+msgstr "Перевести"
+
+msgid "Tray Icon Clicks"
+msgstr "Действия значков трея"
+
+msgid "Tray Icons"
+msgstr "Значки трея"
+
+msgid "Tray icons are drawn by the app itself via XEmbed, so a custom icon cannot "
+"be applied."
+msgstr "Значки трея отрисовываются самим приложением через XEmbed, поэтому "
+"пользовательский значок применить нельзя."
+
+msgid "Type a name or pick an SVG/PNG file."
+msgstr "Введите имя или выберите SVG/PNG файл."
+
+msgid "Unknown"
+msgstr "Неизвестно"
+
+msgid "Unknown App"
+msgstr "Неизвестное приложение"
+
+msgid "Use monochrome icons when available."
+msgstr "Использовать монохромные значки, если они доступны."
+
+msgid "Version"
+msgstr "Версия"
+
+msgid "Vertical (px)"
+msgstr "Вертикально (px)"
+
+msgid "Visible Icons"
+msgstr "Видимые значки"
+
+msgid "Waiting for the file."
+msgstr "Ожидание файла."
+
+msgid "Watching for changes."
+msgstr "Отслеживание изменений."
+
+msgid "Where icons appear in the top panel."
+msgstr "Где значки будут отображаться на верхней панели."
+
+msgid "Wine"
+msgstr "Wine"
+
+msgid "Wine App Icons"
+msgstr "Значки приложений Wine"
+
+msgid "available"
+msgstr "доступно"
+
+msgid "Backup deleted"
+msgstr "Резервная копия удалена"
+
+msgid "Delete"
+msgstr "Удалить"
+
+msgid "Delete failed"
+msgstr "Не удалось удалить"
+
+msgid "Delete this backup?"
+msgstr "Удалить эту резервную копию?"
+
+msgid "Maximum Backups"
+msgstr "Максимум резервных копий"
+
+msgid "Restore failed"
+msgstr "Не удалось восстановить"
+
+msgid "The backup file will be permanently removed."
+msgstr "Файл резервной копии будет удалён безвозвратно."

--- a/src/const.js
+++ b/src/const.js
@@ -229,4 +229,5 @@ export const MAX_CONTRIBUTORS = 5;
 export const CONTRIBUTORS_OPTOUT = new Set([
     'github-actions[bot]',
     'dependabot[bot]',
+    'Agent19872',
 ]);


### PR DESCRIPTION
Adds Russian translation for Better Tray Icons.

Changes:
- Added `po/ru.po`
- Translated the extension preferences and user-facing strings into Russian
- Checked the translation with `msgfmt -c -o /dev/null po/ru.po`
- Built and tested the extension locally to verify that the translation is displayed correctly in the UI
- Added myself to the contributors opt-out list
<img width="1067" height="750" alt="image" src="https://github.com/user-attachments/assets/4448e2a9-70fb-45ac-b059-9572b451e7b7" />
