### PR TITLE
fix: keep the overflow popup open when it should stay open

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -13,6 +13,7 @@ import {placeIndicatorInPanel} from './src/shell/utils/actor.js';
 import {clearIconCaches} from './src/shell/utils/icons.js';
 import {enableLauncherEntries, disableLauncherEntries} from './src/shell/utils/launcherEntries.js';
 import {clearItemSplits} from './src/shell/utils/itemSplit.js';
+import {clearDetachedMenuManager} from './src/shell/utils/actor.js';
 
 import {PanelIndicator} from './src/shell/panel/panelIndicator.js';
 import {SniWatcher} from './src/shell/sni/sniWatcher.js';
@@ -222,6 +223,7 @@ export default class BetterTrayIconsExtension extends Extension {
         clearIconCaches();
         clearSeenCache();
         clearItemSplits();
+        clearDetachedMenuManager();
         clearWarnedOnce();
         this._settings = null;
     }

--- a/src/shell/backgroundAppsProxy/backgroundAppsProxyIcon.js
+++ b/src/shell/backgroundAppsProxy/backgroundAppsProxyIcon.js
@@ -1,14 +1,13 @@
 import Clutter from 'gi://Clutter';
 import Gio from 'gi://Gio';
 import {gettext as _} from 'resource:///org/gnome/shell/extensions/extension.js';
-import * as Main from 'resource:///org/gnome/shell/ui/main.js';
 import * as PopupMenu from 'resource:///org/gnome/shell/ui/popupMenu.js';
 import * as Util from 'resource:///org/gnome/shell/misc/util.js';
 
 import {warn} from '../../shared/logging.js';
 import {configRenderDelta, displayAppName, reseedIfForgotten, unreadBadgeEnabled, updateAppConfig} from '../../shared/appConfig.js';
 import {disconnectAll, disposeAll, ruleDispatcher} from '../../shared/lifecycle.js';
-import {attachStatusIcon, createPanelMenu, destroyMenuSafely, isDisposed, menuAnchorFor, refreshTrayStyle, setBadgeContent, setIconContent, syncHoverStyle, trackDisposal, POPUP_ANIMATION_NONE} from '../utils/actor.js';
+import {attachStatusIcon, createPanelMenu, destroyMenuSafely, isDisposed, menuAnchorFor, refreshTrayStyle, registerMenu, setBadgeContent, setIconContent, syncHoverStyle, trackDisposal, POPUP_ANIMATION_NONE} from '../utils/actor.js';
 import {configuredIcon} from '../utils/icons.js';
 import {addUnreadListener, unreadBadge, unreadTargets} from '../utils/launcherEntries.js';
 import {applyTitle, createTrayActor, syncTooltip} from '../features/tooltip.js';
@@ -140,7 +139,9 @@ export class BackgroundAppsProxyIcon {
     _createMenu() {
         const menu = createPanelMenu(menuAnchorFor(this.actor));
         trackDisposal(menu.actor);
-        Main.panel.menuManager?.addMenu(menu);
+        // Detached manager when the icon sits in the overflow popup, so this
+        // menu doesn't close the popup it was clicked in.
+        registerMenu(menu, this.actor);
 
         const show = new PopupMenu.PopupMenuItem(_('Show'));
         show.connect('activate', () => this._activate());

--- a/src/shell/panel/panelIndicator.js
+++ b/src/shell/panel/panelIndicator.js
@@ -248,11 +248,6 @@ export const PanelIndicator = GObject.registerClass({GTypeName: 'BetterTrayIcons
             const overflowIcons = sortedActors.slice(visibleCount);
             const hasOverflow = overflowIcons.length > 0;
 
-            if (this._visibleBox.get_parent() === this)
-                this.remove_child(this._visibleBox);
-            if (toggleActor.get_parent() === this)
-                this.remove_child(toggleActor);
-
             if (hasOverflow) {
                 this._overflowMenu.attachToManager();
                 toggleActor.show();
@@ -270,18 +265,23 @@ export const PanelIndicator = GObject.registerClass({GTypeName: 'BetterTrayIcons
 
             debounceTo(this, '_settleTimeoutId', GEOMETRY_SETTLE_MS, () => this._overflowMenu.updateGeometry());
 
-            if (hasOverflow) {
-                if (togglePos === 'left') {
-                    this.add_child(toggleActor);
-                    this.add_child(this._visibleBox);
-                } else {
-                    this.add_child(this._visibleBox);
-                    this.add_child(toggleActor);
-                }
-            } else {
-                this.add_child(this._visibleBox);
-                this.add_child(toggleActor);
-            }
+            // Ordering by remove_child plus add_child unmaps the toggle for as
+            // long as it sits outside the tree, and PopupMenu closes itself the
+            // moment its source actor goes unmapped (js/ui/popupMenu.js, the
+            // notify::mapped handler on sourceActor). The toggle is exactly
+            // that source actor, so a relayout during an open popup shut it,
+            // which is what a drop does through its own reorder.
+            // set_child_at_index moves a child already in place instead.
+            const order = hasOverflow && togglePos === 'left'
+                ? [toggleActor, this._visibleBox]
+                : [this._visibleBox, toggleActor];
+
+            order.forEach((child, index) => {
+                if (child.get_parent() === this)
+                    this.set_child_at_index(child, index);
+                else
+                    this.insert_child_at_index(child, index);
+            });
 
             this._lastLayoutSignature = this._computeLayoutSignature();
         }
@@ -382,15 +382,14 @@ export const PanelIndicator = GObject.registerClass({GTypeName: 'BetterTrayIcons
             this._menuRemovedForDrag = false;
             this._toggleButton?.applyHoverMenuOrder();
 
-            if (!this._settings.get_boolean('keep-popup-after-click')) {
-                this._overflowMenu?.close();
-                this._overflowMenu?.attachToManager();
-                return;
-            }
-
-            // The popup stays open, it only lost its manager grab for the
-            // drag. DND pops its own grab right after this handler returns,
-            // so taking ours now would pop out of order.
+            // Not gated on keep-popup-after-click: that setting is about a
+            // click that fires an icon's own action, and closing the popup
+            // then is the point. A reorder only rearranges the popup itself,
+            // so it stays up for the next drag either way.
+            //
+            // The popup never really left, it only lost its manager grab for
+            // the drag. DND pops its own grab right after this handler
+            // returns, so taking ours now would pop out of order.
             debounceTo(this, '_menuRegrabId', MENU_REGRAB_DELAY_MS, () => {
                 this._overflowMenu?.attachToManager();
                 this._overflowMenu?.restoreManagerGrab();

--- a/src/shell/sni/trayIcon.js
+++ b/src/shell/sni/trayIcon.js
@@ -1,6 +1,6 @@
 import GLib from 'gi://GLib';
 
-import {warn} from '../../shared/logging.js';
+import {warn, warnOnce} from '../../shared/logging.js';
 import {configRenderDelta, getAppConfigMap, getAppConfigValue, setAppConfigValue, updateAppConfig, reseedIfForgotten, formatAppName, isVolatileIconName, unreadBadgeEnabled} from '../../shared/appConfig.js';
 import {clearIds, debounceTo, disconnectSignal, disconnectAll, disposeAll, removeTimer, ruleDispatcher} from '../../shared/lifecycle.js';
 import {getItemAddress, refreshPropertyOnProxy, refreshStringOnProxy} from '../utils/dbus.js';
@@ -283,12 +283,10 @@ export class TrayIcon {
 
         switch (action) {
         case 'activate':
-            this._proxy.ActivateRemote(0, 0);
-            this._onCloseMenu();
+            this._fireAndClose('ActivateRemote');
             break;
         case 'secondary':
-            this._proxy.SecondaryActivateRemote(0, 0);
-            this._onCloseMenu();
+            this._fireAndClose('SecondaryActivateRemote');
             break;
         case 'menu':
             // The click that closes a popup also fires here, which would
@@ -298,6 +296,28 @@ export class TrayIcon {
             this._contextMenu();
             break;
         }
+    }
+
+    // Closing the overflow popup is the reward for a click that landed. Items
+    // that never implemented the method answer UnknownMethod, LocalSend among
+    // them, and closing then drops the user out of the popup having achieved
+    // nothing. Leaving it up keeps the icon in reach for a right click or a
+    // double click instead. Only the reply says which of the two happened, so
+    // the close waits for it rather than assuming.
+    //
+    // An app that answers and then does nothing, OpenRGB among them, is
+    // indistinguishable from one that worked and stays on the closing path.
+    _fireAndClose(method) {
+        this._proxy[method](0, 0, (_result, err) => {
+            if (this._isDestroyed)
+                return;
+            if (err) {
+                warnOnce(`${method}:${this.appId}`,
+                    `${this.id} does not answer ${method}, leaving the popup open: ${err.message}`);
+                return;
+            }
+            this._onCloseMenu();
+        });
     }
 
     // Runs for an unidentified item too: it has no stored config, but the

--- a/src/shell/sni/trayIcon.js
+++ b/src/shell/sni/trayIcon.js
@@ -1,5 +1,4 @@
 import GLib from 'gi://GLib';
-import * as Main from 'resource:///org/gnome/shell/ui/main.js';
 
 import {warn} from '../../shared/logging.js';
 import {configRenderDelta, getAppConfigMap, getAppConfigValue, setAppConfigValue, updateAppConfig, reseedIfForgotten, formatAppName, isVolatileIconName, unreadBadgeEnabled} from '../../shared/appConfig.js';
@@ -8,7 +7,7 @@ import {getItemAddress, refreshPropertyOnProxy, refreshStringOnProxy} from '../u
 import {identifyApp, resolveTrayIcon} from '../utils/icons.js';
 import {pickDisplayTitle} from '../utils/appId.js';
 import {forgetItem} from '../utils/itemSplit.js';
-import {attachStatusIcon, isDisposed, trackDisposal, createPanelMenu, menuAnchorFor, destroyMenuSafely, refreshTrayStyle, setBadgeContent, setIconContent, syncHoverStyle, POPUP_ANIMATION_NONE} from '../utils/actor.js';
+import {attachStatusIcon, isDisposed, registerMenu, trackDisposal, createPanelMenu, menuAnchorFor, destroyMenuSafely, refreshTrayStyle, setBadgeContent, setIconContent, syncHoverStyle, POPUP_ANIMATION_NONE} from '../utils/actor.js';
 import {addUnreadListener, unreadTargets} from '../utils/launcherEntries.js';
 import {DBusMenuClient} from './dbusMenuClient.js';
 import {ClickController} from '../features/clickController.js';
@@ -508,9 +507,10 @@ export class TrayIcon {
         this._menu = createPanelMenu(menuAnchorFor(this.actor));
         trackDisposal(this._menu.actor);
 
-        // Hide Top Bar reads Main.panel.menuManager.activeMenu before it collapses,
-        // and a private manager leaves that null while this menu is open.
-        Main.panel.menuManager?.addMenu(this._menu);
+        // The panel's manager for a panel icon, so Hide Top Bar still reads a
+        // live activeMenu; the detached one for an icon in the overflow popup,
+        // so opening this menu doesn't close the popup it was clicked in.
+        registerMenu(this._menu, this.actor);
 
         this._menu.connect('open-state-changed', (menu, isOpen) => {
             if (isOpen)

--- a/src/shell/utils/actor.js
+++ b/src/shell/utils/actor.js
@@ -130,6 +130,36 @@ export function menuAnchorFor(actor) {
     return Main.layoutManager.dummyCursor;
 }
 
+// PopupMenuManager._onMenuOpenState closes the active menu whenever another
+// one opens, unconditionally: there is no child-menu exemption to opt into
+// (js/ui/popupMenu.js, GNOME Shell 50). With the overflow popup and an icon's
+// own context menu both in Main.panel.menuManager, opening the context menu
+// closed the popup out from under it.
+//
+// A second manager for the menus opened from inside the popup is what keeps
+// them apart. The managers push their modal grabs independently, so the
+// context menu stacks on top of the popup's grab instead of replacing it, and
+// closing it hands control back to the still-open popup.
+//
+// Panel icons keep using the panel's manager: there is no popup to protect,
+// and Hide Top Bar reads Main.panel.menuManager.activeMenu before it
+// collapses. For a popup icon that read still lands on the popup, which is
+// open the whole time the context menu is up.
+let _detachedMenuManager = null;
+
+export function registerMenu(menu, actor) {
+    let manager = Main.panel.menuManager;
+    if (!Main.panel.contains(actor))
+        manager = _detachedMenuManager ??= new PopupMenu.PopupMenuManager(Main.layoutManager.uiGroup);
+
+    menu._btiMenuManager = manager;
+    manager?.addMenu(menu);
+}
+
+export function clearDetachedMenuManager() {
+    _detachedMenuManager = null;
+}
+
 // The menu actor can already be C-disposed during shutdown.
 export function destroyMenuSafely(menu) {
     if (!menu || isDisposed(menu.actor))
@@ -140,7 +170,9 @@ export function destroyMenuSafely(menu) {
     if (menu.isOpen)
         menu.close(POPUP_ANIMATION_NONE);
 
-    Main.panel.menuManager?.removeMenu(menu);
+    // Menus opened from inside the overflow popup are held by the detached
+    // manager, and only the manager that owns one can drop it.
+    (menu._btiMenuManager ?? Main.panel.menuManager)?.removeMenu(menu);
     menu.destroy();
 }
 


### PR DESCRIPTION
Hi,

This is about the overflow menu closing after reordering icons, from #35. You said back then that you wanted to rework the drag and drop behavior anyway and that the refactor had grown too big for that update, and the issue ended up closed once the red dot half was solved, so this part is still around.

It kept bothering me, so I had a go at it on my own install. It turned out that three separate things close the popup: right clicking an icon, left clicking an icon (no matter if the app responds or not), and reordering icons with drag-and-drop. This addresses all three. Right click and a drag-and-drop reorder now leave the popup open, and a left click still closes it, but only when the app actually responds to the Activate command: quite a few tray apps do not implement Activate at all, and on those the popup was closing for nothing on 3.0.6. An exception though: a minority of apps _respond_ to Activate without actually opening the window. For those the fix isn't useful.

I have been running this for a while and it works well for me, but that is one machine and my own habits. If you have a moment, it might be worth a look and a try on your own setup. And if you would rather do the proper drag and drop rework you had in mind, please just close this, no hard feelings at all. The commit messages explain what I found and where, in case any of it saves you some time.

Tested on GNOME Shell 50.1, Ubuntu 26.04, Wayland, on top of 3.0.6, and `npm test` passes. For GNOME 49 I compared the parts of the shell this relies on and they are unchanged from 50, so it should hold there as well, but I have no 49 machine to actually try it on.

The two commits are independent, the second one can be dropped on its own.

One thing I want to say plainly, because of the AI rule in CONTRIBUTING.md: I did not write this code by hand, I worked it out together with an AI assistant, and the commits carry a `Co-Authored-By` trailer for that reason. I completely understand if that alone makes it a no.